### PR TITLE
Remove unneeded dependencies to reduce plugin size

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,7 @@
 <html>
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <script type="text/javascript" charset="utf-8" src="http://cdn.clappr.io/0.2.54/clappr.min.js"></script>
+  <script type="text/javascript" charset="utf-8" src="https://cdn.jsdelivr.net/clappr/latest/clappr.min.js"></script>
   <script type="text/javascript" charset="utf-8" src="../dist/clappr0-hlsjs-provider.js"> </script>
 
   <script src="http://cdnjs.cloudflare.com/ajax/libs/rickshaw/1.4.6/rickshaw.min.js"> </script>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "clappr": "^0.2.54",
     "streamroot-hlsjs-p2p-bundle": "^4.0.0"
   },
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,14 @@ module.exports = {
             test: /\.js$/
         }]
     },
+    externals: {
+        clappr: {
+            amd: 'clappr',
+            commonjs: 'clappr',
+            commonjs2: 'clappr',
+            root: 'Clappr'
+        }
+    },
     plugins: [
         new webpack.DefinePlugin({
             __VERSION__: JSON.stringify(`v${version}`)


### PR DESCRIPTION
Hi,

This PR remove Clappr from dependencies and define Clappr in Webpack externals configuration.

Previously, the plugin was compiled with Clappr player module included (which is not needed). With theses changes, Clappr is not included anymore, which reduce plugin size from ~ 997k to ~ 510k.
